### PR TITLE
Run Kestrel  testing flow on ubuntu-22.04

### DIFF
--- a/.github/workflows/kestrel-end-to-end-testing-flow.yml
+++ b/.github/workflows/kestrel-end-to-end-testing-flow.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   kestrel-end-to-end-testing:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
         kestrel_analytics_branch: release
         venv_activate:

--- a/.github/workflows/scalability-flow.yml
+++ b/.github/workflows/scalability-flow.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   kestrel-scalability-testing:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
         venv_activate:
     steps:

--- a/.github/workflows/stix-shifter-kestrel-testing-flow.yml
+++ b/.github/workflows/stix-shifter-kestrel-testing-flow.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   end-to-end-testing:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
         kestrel_analytics_branch: release
         venv_activate: 


### PR DESCRIPTION
Bump the OS used by the github runner to ubuntu22-04 (from ubuntu-20.04)